### PR TITLE
Renamed injected properties for compatibility with ColdBox 6.5.2

### DIFF
--- a/handlers/Registrations.cfc
+++ b/handlers/Registrations.cfc
@@ -1,6 +1,6 @@
 component {
 
-	property name="auth" inject="AuthenticationService@cbauth";
+	property name="_auth" inject="AuthenticationService@cbauth";
 	property name="flash" inject="coldbox:flash";
 
 	function new( event, rc, prc ){
@@ -29,7 +29,7 @@ component {
 
 		var user = getInstance( "User" ).create( { "email" : rc.email, "password" : rc.password } );
 
-		auth.login( user );
+		_auth.login( user );
 
 		relocate( uri = "/" );
 	}

--- a/handlers/Sessions.cfc
+++ b/handlers/Sessions.cfc
@@ -1,6 +1,6 @@
 component {
 
-	property name="auth" inject="AuthenticationService@cbauth";
+	property name="_auth" inject="AuthenticationService@cbauth";
 	property name="flash" inject="coldbox:flash";
 
 	function new( event, rc, prc ){
@@ -20,7 +20,7 @@ component {
 		}
 
 		try{
-			auth.authenticate( rc.email, rc.password );
+			_auth.authenticate( rc.email, rc.password );
 			relocate( uri = "/" );
 		} catch ( InvalidCredentials e ) {
 			flash.put( "errors", { "login" : "Invalid Credentials" } );
@@ -29,7 +29,7 @@ component {
 	}
 
 	function delete( event, rc, prc ){
-		auth.logout();
+		_auth.logout();
 		relocate( uri = "/" );
 	}
 

--- a/interceptors/SharedInertiaDataInterceptor.cfc
+++ b/interceptors/SharedInertiaDataInterceptor.cfc
@@ -1,20 +1,20 @@
 component {
 
-	property name="inertia" inject="provider:Inertia@cbInertia";
-	property name="auth" inject="provider:AuthenticationService@cbauth";
+	property name="_inertia" inject="provider:Inertia@cbInertia";
+	property name="_auth" inject="provider:AuthenticationService@cbauth";
 	property name="flash" inject="coldbox:flash";
 
 	function preProcess(){
-		inertia.share(
+		_inertia.share(
 			"auth",
 			{
 				"user" : function() {
-					return auth.check() ? auth.user().getMemento() : javacast( "null", "" );
+					return _auth.check() ? _auth.user().getMemento() : javacast( "null", "" );
 				}
 			}
 		);
 
-		inertia.share( "errors", function() {
+		_inertia.share( "errors", function() {
 			return flash.get( "errors", {} );
 		} );
 	}


### PR DESCRIPTION
Updating to ColdBox 6.5.2 would give `Routines cannot be declared more than once` error. 

https://coldbox.ortusbooks.com/intro/release-history/whats-new-with-6.5.0#compatibility-notes

Renamed injected properties for cbauth and cbinertia.
